### PR TITLE
Report bitfield as a percentage

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,8 @@
+import test from 'ava';
+import { completedPieceCount } from '../src/utils.js';
+
+test('completedPieceCount', t => {
+    t.deepEqual(completedPieceCount(Buffer.from([0x80])), 1);
+    t.deepEqual(completedPieceCount(Buffer.from([0xFF])), 8);
+    t.deepEqual(completedPieceCount(Buffer.from([0x33, 0x44])), 6);
+})

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -2,7 +2,7 @@
 import bencode from 'bencode';
 import { Socket } from "net";
 import { getLogger } from "./logger.js";
-import { hexdump } from "./utils.js";
+import { completedPieceCount, hexdump } from "./utils.js";
 
 type Resolver = {
     resolve: (v: unknown) => void,
@@ -191,7 +191,7 @@ export class Peer {
 
         if (messageType === MessageTypes.Bitfield){
             const bitfield = new Bitifeld(message.subarray(1));
-            logger.info(`Received bitfield: ${bitfield}`);
+            logger.debug(`Raw bitfield: ${bitfield}`);
         } else if (messageType === MessageTypes.Extended){
             const extended = new Extended(message.subarray(1))
             // console.log(`Got extended: ${extended}`);
@@ -223,8 +223,13 @@ type Message = {
 
 class Bitifeld implements Message {
     type = MessageTypes.Bitfield;
+    completed: number;
 
     constructor(public raw: Buffer){
+        const logger = getLogger();
+        this.completed = completedPieceCount(raw);
+        let perc = (this.completed / (raw.length * 8)) * 100;
+        logger.info(`Received bitfield: ~${perc}% complete`);
 
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,3 +10,31 @@ export const hexdump = (data: Buffer): string => {
     output += `0x${hexString.substring(len-2, len).toLocaleUpperCase()}]`;
     return output;
 }
+
+// number of bits set in a particular nibble
+// e.g. 0x3 = 0b0101 = two bits set
+// thanks https://stackoverflow.com/a/25808559
+export const NIBBLE_LOOKUP = [0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4]
+
+/**
+ * Checks how many pieces you have out of the total
+ * 
+ * Since we don't know how many pieces there are in total, we assume
+ * it is bitfield.length * 8
+ * But of course, if there is only one piece, it would still need a whole byte to carry the bitfield
+ * for 0b1000_0000 (aka 0x80)
+ * 
+ * so the variance in length is a max of 7 pieces
+ * but of course, if any of those bits are non-zero,
+ * then it must actually be there.
+ */
+export const completedPieceCount = (bitfield: Buffer): number => {
+    let completed = 0
+
+    for (let i = 0; i < bitfield.length; i++){
+        completed += NIBBLE_LOOKUP[bitfield[i] & 0x0F] // lower 4 bits
+        completed += NIBBLE_LOOKUP[bitfield[i] >> 4]; // upper 4 bits
+    }
+    
+    return completed;
+}


### PR DESCRIPTION
```
2023-09-10T06:46:13.928Z [INF]: Connected to [REDACTED]! (TCP Connection success)
2023-09-10T06:46:14.138Z [INF]: Client: libTorrent 0.13.7
2023-09-10T06:46:14.138Z [INF]: Supported extensions: ut_metadata,ut_pex
2023-09-10T06:46:14.139Z [INF]: Recevied handshake! (Success)
2023-09-10T06:46:14.338Z [INF]: Received bitfield: ~92.5% complete
```